### PR TITLE
Update resnetcifar.py license 

### DIFF
--- a/passl/modeling/backbones/resnetcifar.py
+++ b/passl/modeling/backbones/resnetcifar.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Modify license from 2020 to 2021.