### PR TITLE
fix bug of mixup

### DIFF
--- a/configs/deit/deit-base-p16-pt_in1k-224_2n16c_fp16_o1_dp.yaml
+++ b/configs/deit/deit-base-p16-pt_in1k-224_2n16c_fp16_o1_dp.yaml
@@ -1,6 +1,5 @@
 epochs: 300 
 output_dir: output_dir
-seed: 2021
 
 use_amp: True
 AMP:
@@ -11,7 +10,7 @@ AMP:
    auto_cast:
      enable: True
      custom_black_list: ["reduce_mean", "reduce_sum",
-                         "sigmoid_cross_entropy_with_logits", "elementwise_div"]
+                         "log_softmax", "elementwise_div"]
      level: 'O1'
 
 model:
@@ -47,6 +46,7 @@ dataloader:
           return_type: numpy
         - name: RandCropImage
           size: 224
+          scale: [0.05, 1.0]
           interpolation: bicubic
           backend: pil
         - name: RandomHorizontalFlip
@@ -72,7 +72,7 @@ dataloader:
           cutmix_alpha: 1.0
           label_smoothing: 0.1
           num_classes: 1000
-          
+
   val:
     num_workers: 8
     sampler:

--- a/passl/datasets/preprocess/mixup.py
+++ b/passl/datasets/preprocess/mixup.py
@@ -98,7 +98,6 @@ def cutmix_bbox_and_lam(img_shape,
     if ratio_minmax is not None:
         yl, yu, xl, xu = rand_bbox_minmax(img_shape, ratio_minmax, count=count)
     else:
-        lam = np.clip(lam, 0.9999, 0.9999)
         yl, yu, xl, xu = rand_bbox(img_shape, lam, count=count)
     if correct_lam or ratio_minmax is not None:
         bbox_area = (yu - yl) * (xu - xl)


### PR DESCRIPTION
DeiT/B-16 pretrained on ImageNet1K:

```
[01/21 02:54:46] passl.engine.trainer INFO: Validate Epoch [290] acc1 (81.336), acc5 (95.544)
[01/21 03:02:31] passl.engine.trainer INFO: Validate Epoch [291] acc1 (81.328), acc5 (95.580)
[01/21 03:10:20] passl.engine.trainer INFO: Validate Epoch [292] acc1 (81.390), acc5 (95.608)
[01/21 03:18:10] passl.engine.trainer INFO: Validate Epoch [293] acc1 (81.484), acc5 (95.636)
[01/21 03:26:00] passl.engine.trainer INFO: Validate Epoch [294] acc1 (81.452), acc5 (95.600)
[01/21 03:33:52] passl.engine.trainer INFO: Validate Epoch [295] acc1 (81.354), acc5 (95.528)
[01/21 03:41:38] passl.engine.trainer INFO: Validate Epoch [296] acc1 (81.338), acc5 (95.562)
[01/21 03:49:25] passl.engine.trainer INFO: Validate Epoch [297] acc1 (81.344), acc5 (95.542)
[01/21 03:57:15] passl.engine.trainer INFO: Validate Epoch [298] acc1 (81.476), acc5 (95.550)
[01/21 04:05:03] passl.engine.trainer INFO: Validate Epoch [299] acc1 (81.476), acc5 (95.572)
[01/21 04:12:51] passl.engine.trainer INFO: Validate Epoch [300] acc1 (81.386), acc5 (95.536)
```