### PR TITLE
fix bug for python 3.7 to python 3.10

### DIFF
--- a/passl/core/param_fuse.py
+++ b/passl/core/param_fuse.py
@@ -201,10 +201,8 @@ class ParamStorage(object):
 
         # Convert the param value
         tmp_tensor = self.buffer._slice(self._fill, var_end)
-        if in_dygraph_mode():
-            tmp_tensor = tmp_tensor.value().get_tensor()
-        param.value().get_tensor()._share_data_with(tmp_tensor)
-        param.value().get_tensor()._set_dims(p_shape)
+        tmp_tensor._share_buffer_to(param)
+        param.get_tensor()._set_dims(p_shape)
 
         self._fill = offset
 

--- a/passl/models/utils/pos_embed.py
+++ b/passl/models/utils/pos_embed.py
@@ -67,7 +67,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
     out: (M, D)
     """
     assert embed_dim % 2 == 0
-    omega = np.arange(embed_dim // 2, dtype=np.float)
+    omega = np.arange(embed_dim // 2, dtype=np.float32)
     omega /= embed_dim / 2.
     omega = 1. / 10000**omega  # (D/2,)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ prettytable
 tqdm
 visualdl
 scikit-learn>=0.23.2
-opencv-python>=4.2.0.32
-onnxruntime-gpu==1.10.0
-onnx==1.9.0
-paddle2onnx==0.9.4
+opencv-python
+onnxruntime-gpu
+onnx
+paddle2onnx


### PR DESCRIPTION
* 修复 python 3.7 到 python 3.10 的升级 bug
* 修复 https://github.com/PaddlePaddle/Paddle/pull/55279 导致 `segment fault` 错误